### PR TITLE
Misc updates to fix JS and URI syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage/
+node_modules

--- a/lib/swagger-test.js
+++ b/lib/swagger-test.js
@@ -2,11 +2,19 @@
 
 var template = require('url-template');
 
+function getUriScheme(spec) {
+    var defaultScheme='https';
+    if(spec.schemes == undefined || !(spec.schemes instanceof Array) || spec.schemes.length < 1) {
+      return defaultScheme;
+    }
+    return spec.schemes[0]
+}
+
 function parseXample(spec, uri, method, xample) {
     var uriTemplate = template.parse(uri);
     var expandedUri = uriTemplate.expand(xample.request.params);
     xample.request.method = method;
-    xample.request.uri = spec.host + spec.basePath + expandedUri;
+    xample.request.uri = getUriScheme(spec) + '://' + spec.host + spec.basePath + expandedUri;
     return {
         description: xample.description || method + ' ' + uri,
         request: xample.request,
@@ -17,7 +25,7 @@ function parseXample(spec, uri, method, xample) {
 function inferXample(spec, uri, method, operation, statusString) {
     var request = {
         method: method,
-        uri: spec.host + spec.basePath + uri
+        uri: getUriScheme(spec) + '://' + spec.host + spec.basePath + uri
     };
     var responses = {};
     if (operation.produces && operation.produces[0]) {

--- a/lib/swagger-test.js
+++ b/lib/swagger-test.js
@@ -7,7 +7,7 @@ function getUriScheme(spec) {
     if(spec.schemes == undefined || !(spec.schemes instanceof Array) || spec.schemes.length < 1) {
       return defaultScheme;
     }
-    return spec.schemes[0]
+    return spec.schemes[0];
 }
 
 function parseXample(spec, uri, method, xample) {

--- a/swagger-test.js
+++ b/swagger-test.js
@@ -21,7 +21,7 @@ rl.on('close', function () {
   var xamples = swaggerTest.parse(swaggerSpec);
     xamples.forEach(function (xample) {
     preq[xample.request.method](xample.request).then(function (response) {
-      if (response.status && xample.responses[response.status] {
+      if (response.status && xample.responses[response.status]) {
         var xampleResponse = xample.responses[response.status];
         if (response.headers && xampleResponse.headers) {
           for (var h in response.headers) {

--- a/test/swagger.json
+++ b/test/swagger.json
@@ -1,6 +1,7 @@
 {
   "swagger": "2.0",
   "host": "localhost",
+  "schemes": ["http"],
   "info": {
     "version": "1.0.0",
     "title": "Pet store"

--- a/test/tests.js
+++ b/test/tests.js
@@ -23,7 +23,7 @@ describe('test generation with inference', function () {
           "description": "get /pets",
           "request": {
               "method": "get",
-              "uri": "localhost/v1/pets"
+              "uri": "http://localhost/v1/pets"
           },
           "responses": {
               "200": {
@@ -43,7 +43,7 @@ describe('test generation with inference', function () {
                   "id": "fido4"
               },
               "method": "get",
-              "uri": "localhost/v1/pets/fido4"
+              "uri": "http://localhost/v1/pets/fido4"
           },
           "responses": {
               "200": {
@@ -63,7 +63,7 @@ describe('test generation with inference', function () {
                 "id": "fido7"
             },
             "method": "get",
-            "uri": "localhost/v1/pets/fido7"
+            "uri": "http://localhost/v1/pets/fido7"
         },
         "responses": {
             "200": {


### PR DESCRIPTION
This pull request updates a few minor issues-

- the main file contains a syntax error
- the tests produce URI's with no scheme (the `schemes` key in the swagger format should be used if listed, while `https` is the best assumption if guessing). Based on the test cases, this may have been allowed in previous versions of the dependencies, but it gets me an exception.
- test fixes for above
- `node_modules` should be listed in the `.gitignore` file

Stack traces for the issues being fixed are shown below.

```bash
$ node -v
v6.9.5
```

Syntax issue:

```bash
$ node swagger-test.js 
/home/mike/workspace/swagger-test/swagger-test.js:24
      if (response.status && xample.responses[response.status] {
                                                               ^
SyntaxError: Unexpected token {
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```

Missing URI scheme:

```bash
$ node swagger-test.js < test/swagger.json 
Unhandled rejection Error: Invalid URI "localhost/v1/pets/fido4"
    at Request.init (/home/mike/workspace/swagger-test/node_modules/request/request.js:274:31)
    at new Request (/home/mike/workspace/swagger-test/node_modules/request/request.js:128:8)
    at request (/home/mike/workspace/swagger-test/node_modules/request/index.js:54:10)
    at tryCatcher (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/util.js:16:23)
    at ret (eval at makeNodePromisifiedEval (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promisify.js:184:12), <anonymous>:14:23)
    at /home/mike/workspace/swagger-test/node_modules/preq/index.js:181:38
    at tryCatcher (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/util.js:16:23)
    at Function.Promise.attempt.Promise.try (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/method.js:39:29)
    at Request.run (/home/mike/workspace/swagger-test/node_modules/preq/index.js:181:17)
    at Request.tryCatcher (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:691:18)
    at Promise._fulfill (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:636:18)
    at Promise._resolveCallback (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:431:57)

Unhandled rejection Error: Invalid URI "localhost/v1/pets/fido7"
    at Request.init (/home/mike/workspace/swagger-test/node_modules/request/request.js:274:31)
    at new Request (/home/mike/workspace/swagger-test/node_modules/request/request.js:128:8)
    at request (/home/mike/workspace/swagger-test/node_modules/request/index.js:54:10)
    at tryCatcher (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/util.js:16:23)
    at ret (eval at makeNodePromisifiedEval (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promisify.js:184:12), <anonymous>:14:23)
    at /home/mike/workspace/swagger-test/node_modules/preq/index.js:181:38
    at tryCatcher (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/util.js:16:23)
    at Function.Promise.attempt.Promise.try (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/method.js:39:29)
    at Request.run (/home/mike/workspace/swagger-test/node_modules/preq/index.js:181:17)
    at Request.tryCatcher (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:691:18)
    at Promise._fulfill (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:636:18)
    at Promise._resolveCallback (/home/mike/workspace/swagger-test/node_modules/bluebird/js/release/promise.js:431:57)
```
